### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,7 +4,7 @@
   "version": "2.0.0",
   "categories": ["export", "dicom"],
   "description": "Export volume project to Google Cloud Storage, Amazon S3, Microsoft Azure, ...",
-  "docker_image": "supervisely/import-export:6.73.460",
+  "docker_image": "supervisely/import-export:6.73.564",
   "instance_version": "6.15.2",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "categories": ["export", "dicom"],
   "description": "Export volume project to Google Cloud Storage, Amazon S3, Microsoft Azure, ...",
   "docker_image": "supervisely/import-export:6.73.564",
-  "instance_version": "6.15.2",
+  "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
   "modal_template_state": {

--- a/config.json
+++ b/config.json
@@ -2,9 +2,12 @@
   "name": "Export volume project to cloud storage",
   "type": "app",
   "version": "2.0.0",
-  "categories": ["export", "dicom"],
+  "categories": [
+    "export",
+    "dicom"
+  ],
   "description": "Export volume project to Google Cloud Storage, Amazon S3, Microsoft Azure, ...",
-  "docker_image": "supervisely/import-export:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "main_script": "src/main.py",
   "modal_template": "src/modal.html",
@@ -19,7 +22,10 @@
   "isolate": true,
   "headless": true,
   "context_menu": {
-    "target": ["volumes_project", "volumes_dataset"],
+    "target": [
+      "volumes_project",
+      "volumes_dataset"
+    ],
     "context_root": "Download as"
   },
   "icon": "https://user-images.githubusercontent.com/48913536/214856602-14c5b5bd-a5f5-4adc-9d5f-c52f775dc399.png",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.460
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
